### PR TITLE
Check more suffixes for linking boost_python

### DIFF
--- a/recipe/boostpythonsuffixes.patch
+++ b/recipe/boostpythonsuffixes.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index 2a36c69..55c9521 100755
+--- a/setup.py
++++ b/setup.py
+@@ -39,8 +39,11 @@ def get_boost_libraries():
+     on the system. If required libraries are not found, an Exception will be
+     thrown.
+     """
+-    baselib = "boost_python3" if PY3 else "boost_python"
+-    boostlibtags = ['', '-mt'] + ['']
++    baselib = "boost_python"
++    major, minor = (str(x) for x in sys.version_info[:2])
++    pytags = [major + '.' + minor, major, '']
++    mttags = ['', '-mt']
++    boostlibtags = [(pt + mt) for mt in mttags for pt in pytags] + ['']
+     from ctypes.util import find_library
+     for tag in boostlibtags:
+         lib = baselib + tag

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - scattering.patch
+    - boostpythonsuffixes.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or py2k]
   script: python setup.py install
 


### PR DESCRIPTION
boost_python library for Python X.Y may have suffixes "X.Y", "X",
"", "X.Y-mt", etc.  Check them all to determine proper library name.